### PR TITLE
Removing unnecessary URL and version params

### DIFF
--- a/app.js
+++ b/app.js
@@ -32,7 +32,8 @@ var conversation = new Conversation({
   // After that, the SDK will fall back to the bluemix-provided VCAP_SERVICES environment property
   // username: '<username>',
   // password: '<password>',
-  version_date: '2016-10-21',
+  // url: 'https://gateway.watsonplatform.net/conversation/api',
+  version_date: Conversation.VERSION_DATE_2017_04_21
 });
 
 // Endpoint to be call from the client side

--- a/app.js
+++ b/app.js
@@ -32,9 +32,7 @@ var conversation = new Conversation({
   // After that, the SDK will fall back to the bluemix-provided VCAP_SERVICES environment property
   // username: '<username>',
   // password: '<password>',
-  url: 'https://gateway.watsonplatform.net/conversation/api',
   version_date: '2016-10-21',
-  version: 'v1'
 });
 
 // Endpoint to be call from the client side

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "body-parser": "^1.15.2",
     "dotenv": "^2.0.0",
     "express": "^4.14.0",
-    "watson-developer-cloud": "^2.8.1"
+    "watson-developer-cloud": "^2.31.1"
   },
   "devDependencies": {
     "babel-eslint": "^6.0.4",


### PR DESCRIPTION
The conversationV1 constructor defaults to the provided US url, and the version is already specified in the require path (line 21). 

(Also, hard-coding the URL means this demo won't work without modification in other bluemix regions, because it overrides the region-specific one provided in VCAP_SERVICES - https://github.com/watson-developer-cloud/node-sdk/issues/449)

I also switched the version_date from a string to a constant and updated the node sdk dependency version to ensure the constant is available.